### PR TITLE
Assign codeowners to tm-sudo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-sudo


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-sudo as codeowners.

    Note: This is a shared library and the team assignment was done randomly as part of an initial organization effort. 
    If you believe this assignment should be adjusted, please follow the procedure (first step is to suggest another team and tag it).